### PR TITLE
correct the restore flags help output

### DIFF
--- a/pkg/cmd/restore.go
+++ b/pkg/cmd/restore.go
@@ -34,11 +34,15 @@ func init() {
 	restoreCmd.PersistentFlags().String(
 		FlagRestoreSourceDir,
 		defaultValue(FlagRestoreSourceDir, "."),
-		fmt.Sprintf("a directory with all artefacts (${%s})", FlagRestoreSourceDir))
+		fmt.Sprintf(
+			"a directory with all artefacts (${%s})",
+			GetEnvName(FlagRestoreSourceDir)))
 	restoreCmd.PersistentFlags().String(
 		FlagRestoreDestDir,
 		defaultValue(FlagRestoreDestDir, "."),
-		fmt.Sprintf("a directory to start the restore process from (%s)", FlagRestoreSourceDir))
+		fmt.Sprintf(
+			"a directory to start the restore process from (${%s})",
+			GetEnvName(FlagRestoreDestDir)))
 
 	RootCmd.AddCommand(restoreCmd)
 }


### PR DESCRIPTION
This fixes wrong output (the `--dest-dir` mentions the source-dir and the `--source-dir` mentions a bad environment variable:
```
Flags:
      --dest-dir string     a directory to start the restore process from (source-dir) (default ".")
  -h, --help                help for restore
      --source-dir string   a directory with all artefacts (${source-dir}) (default ".")
```

Now:
```
Flags:
      --dest-dir string     a directory to start the restore process from (${ARTEFACTOR_DEST_DIR}) (default ".")
  -h, --help                help for restore
      --source-dir string   a directory with all artefacts (${ARTEFACTOR_SOURCE_DIR}) (default ".")
```