### PR TITLE
update docker client connection to negotiate go client version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin
 /downloads
 /vendor
+.idea
+.vscode

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -29,7 +29,7 @@ func Load(file string) error {
 
 	// Get docker client
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func Load(file string) error {
 
 func ReTag(image Image) error {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err
 	}

--- a/pkg/docker/push.go
+++ b/pkg/docker/push.go
@@ -25,7 +25,7 @@ type PushEvent struct {
 // Push will push a docker image
 func Push(image string, creds *util.Creds) error {
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return (err)
 	}

--- a/pkg/docker/save.go
+++ b/pkg/docker/save.go
@@ -44,7 +44,7 @@ func Save(c *hashcache.CheckSumCache, image string, dir string, creds *util.Cred
 	}
 
 	ctx := context.Background()
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return (err)
 	}


### PR DESCRIPTION
To ensure portability when using the newer docker go client SDK, we need to ensure it will execute compatible interface, so negation automatically is possible with this change, based on the host environments docker version.