### PR TITLE
Now tags with origional tag and source repoDigest reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,13 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     environment:
-      MYSQL_IMAGE: "mysql:5.7.27@sha256:1a121f2e7590f949b9ede7809395f209dd9910e331e8372e6682ba4bebcc020b"
-      ALPINE_IMAGE: "nginx:1-alpine"
-      BUSYBOX_IMAGE: "quay.io/google-containers/busybox:1.27.2@sha256:70892b4c36448ecd9418580da9efa2644c20b4401667db6ae0cf15c0dcdaa595"
-      ARTEFACTOR_IMAGE_VARS: "MYSQL_IMAGE ALPINE_IMAGE BUSYBOX_IMAGE"
-      ARTEFACTOR_DOCKER_REGISTRY: "localhost:5000"
       GO111MODULE: "on"
+      ARTEFACTOR_BINARY: "artefactor"
     steps:
       - checkout
       - run: make docker_build
       - run: make docker_get_artefactor_binary
-      - run: ./artefactor save --logs
       - run: make run_publish_e2e_test
-      - run: ./artefactor update-image-vars --logs
 
   release:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,15 @@ VETARGS ?= -asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -print
 PLATFORMS ?= darwin linux
 ARCHITECTURES ?= 386 amd64
 
+ARTEFACTOR_BINARY ?= bin/artefactor
 MYSQL_IMAGE ?= mysql:5.7.27@sha256:1a121f2e7590f949b9ede7809395f209dd9910e331e8372e6682ba4bebcc020b
 BUSYBOX_IMAGE ?= quay.io/google-containers/busybox:1.27.2@sha256:70892b4c36448ecd9418580da9efa2644c20b4401667db6ae0cf15c0dcdaa595
+BUSYBOX2_IMAGE ?= busybox@sha256:442c9d8c2c01192d7f7a05a1b02ba0f4509d9bd28d4d40d67e8f7800740f1483
+BUSYBOX3_IMAGE ?= busybox@sha256:2edbab3ccf5ebe2d1c79131966766ff2156df89ed538e0c8fb9a1f087b503a65
 ALPINE_IMAGE ?= nginx:1-alpine
-ARTEFACTOR_IMAGE_VARS ?= MYSQL_IMAGE ALPINE_IMAGE BUSYBOX_IMAGE
+ARTEFACTOR_IMAGE_VARS ?= MYSQL_IMAGE ALPINE_IMAGE BUSYBOX_IMAGE BUSYBOX2_IMAGE BUSYBOX3_IMAGE
 ARTEFACTOR_DOCKER_REGISTRY ?= localhost:5000
-export MYSQL_IMAGE BUSYBOX_IMAGE ALPINE_IMAGE ARTEFACTOR_IMAGE_VARS ARTEFACTOR_DOCKER_REGISTRY
+export MYSQL_IMAGE BUSYBOX_IMAGE BUSYBOX2_IMAGE BUSYBOX3_IMAGE ALPINE_IMAGE ARTEFACTOR_IMAGE_VARS ARTEFACTOR_DOCKER_REGISTRY
 
 .PHONY: test authors changelog build release lint cover vet
 
@@ -50,19 +53,29 @@ docker_build:
 
 run_publish_e2e_test:
 	@echo "--> running e2e test"
-	./artefactor save --logs
+	./${ARTEFACTOR_BINARY} save --logs
 	docker run -d --rm --name registry -p 5000:5000 registry:2
 	docker ps
 	env |grep -i registry
-	ARTEFACTOR_DOCKER_USERNAME=a ARTEFACTOR_DOCKER_PASSWORD=a ./artefactor publish --logs
+	ARTEFACTOR_DOCKER_USERNAME=a ARTEFACTOR_DOCKER_PASSWORD=a ./${ARTEFACTOR_BINARY} publish --logs
 	docker stop registry
+	@echo "env:" ${ARTEFACTOR_IMAGE_VARS}
+	@env |grep IMAGE
+	./${ARTEFACTOR_BINARY} update-image-vars --logs
 	
+
+run_updateimagevars_test:
+	@echo "--> running update-image-vars test"
+	@echo "env:" ${ARTEFACTOR_IMAGE_VARS}
+	@env |grep IMAGE
+	./${ARTEFACTOR_BINARY} update-image-vars
+
 docker_get_artefactor_binary:
 	@echo "--> retreiveing artefactor binary"
 	docker create \
     --name artefactor-build-${VERSION} \
     ${CONTAINER}:${VERSION} && \
-	docker cp artefactor-build-${VERSION}:/usr/local/bin/artefactor ./artefactor
+	docker cp artefactor-build-${VERSION}:/usr/local/bin/artefactor ${ARTEFACTOR_BINARY}
 	
 docker_push:
 	@echo "--> Pushing container"

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ export CASSANDRA_IMAGE=myreg.local/cassandra:latest
 
 #### Content Adressable Repo Digests
 
-When updating image vars and addressing images using the digest format, eg. `alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998` 
-the `repoDigest` cannot be guaranteed to be the same between registries due to differences in implementations of digest calculation. For this reason, when updating image vars, a local docker instance must have already published the image being updated so a new repoDigest is available and can be updated in the image var.
-for example
+When updating image vars and addressing images using the digest format, eg. `alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998`
+The `repoDigest` cannot be guaranteed to be the same between registries due to differences in implementations of digest calculation. For this reason, when updating image vars, a local docker instance must have already published the image being updated so a new repoDigest is available and can be updated in the image var.
+for example:
 
 ```bash
 export ALPINE_IMAGE="alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998"
@@ -160,7 +160,10 @@ export MYSQL_IMAGE=myreg.local/alpine@sha256:b7b28af77ffec6054d13378df4fdf027258
 
 As can be seen the digest sha has changed. This was picked up from the metadata stored in the local docker instance gathered from the push even `artefactor publish` generates.
 
-**Note**: if the image has not been published from the context the `artefactor update-image-vars` command is being run from, the command will fail with an error not being able to find the image details in the local docker instance.
+**Notes**:
+
+- if the image has not been published from the context the `artefactor update-image-vars` command is being run from, the command will fail with an error not being able to find the image details in the local docker instance.
+- Image stored with the format `imagename:vX.Y.Z@sha256:[64chars]` will be loaded with only an image name and no tag, and then tagged twice when pushed to the destination registry, both with the original tag AND a second reference to the repoDigest it was pulled from at the source registry. This is a convenience to provide a reverse reference for the source of the image since there is no direct reference possible between separate registries.
 
 ### Usage in CI
 


### PR DESCRIPTION
In the case of an image with a repoDigest:
* When there is an original legible tag, update the docker.ReTag method to tag twice, once for the tag that was referenced when pulled and a meta tag of the repoDigest from where it was sourced.
* Where there is only a tag, only the tag is used
* Where there is only a repoDigest, the image is tagged with the source repoDigest against the new registry for reference to the source.