### PR TITLE
Undoing error handling around `calcAndCheckSum`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,11 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       GO111MODULE: "on"
-      ARTEFACTOR_BINARY: "artefactor"
     steps:
       - checkout
       - run: make docker_build
       - run: make docker_get_artefactor_binary
-      - run: make run_publish_e2e_test
+      - run: make run_e2e_test
 
   release:
     docker:

--- a/ci_tests/e2etest.sh
+++ b/ci_tests/e2etest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+function finish {
+  # Your cleanup code here
+  #ensure docke registry is stopped
+  docker stop registry &>/dev/null || true
+  rm -rf $TMPDIR
+}
+trap finish EXIT
+: "${E2E_BREAK_TESTS:=0}"
+: "${ARTEFACTOR_IMAGE_VARS?}" "${ARTEFACTOR_DOCKER_REGISTRY?}" "${ARTEFACTOR_GIT_REPOS?}"
+set -xe
+
+./bin/artefactor save --logs
+
+cd downloads
+
+if E2E_BREAK_TESTS; then
+# uncomment to break e2e test with validate src files are checksumed.
+#get all docker.tar files 
+files=(`ls *.docker.tar`)
+#truncate first file in list.
+cat /dev/null > "${files[0]}"
+fi
+
+TMPDIR=$(mktemp -d)
+./artefactor restore --dest-dir $TMPDIR --logs 
+
+cd "${TMPDIR}/artefactor"
+docker run -d --rm --name registry -p 5000:5000 registry:2
+docker ps
+env |grep -i registry
+
+ARTEFACTOR_DOCKER_USERNAME=a ARTEFACTOR_DODCKER_PASSWORD=a ./downloads/artefactor publish --logs
+
+docker stop registry
+echo "env:" ${ARTEFACTOR_IMAGE_VARS}
+env |grep IMAGE
+./downloads/artefactor update-image-vars --logs

--- a/pkg/cmd/artefactor.go
+++ b/pkg/cmd/artefactor.go
@@ -17,7 +17,7 @@ const (
 	FlagDockerImages = "docker-images"
 	// FlagArchiveDir is the directory to save archives into
 	FlagArchiveDir = "archive-dir"
-	// FlagGitRepos specifies a newline speerated list of local or remote git repos
+	// FlagGitRepos specifies a newline seperated list of local or remote git repos
 	FlagGitRepos = "git-repos"
 	// FlagWebFiles specifies a whitespace delimited set of csv's with:
 	// url,file,md5,[true|false (executable)]


### PR DESCRIPTION
due to errors being ignored in code as a way to step past missing
checksum files when you want to create them, normal error validation
caused issues in the normal execution of the restore process.
removing checks until future work to resolve these patterns in the
code can be taken on.